### PR TITLE
[Sprint 8]: Broken:  (Do not merge) attempt to replace owned strings

### DIFF
--- a/riv/src/component/sink.rs
+++ b/riv/src/component/sink.rs
@@ -5,9 +5,9 @@ use std::fmt::{Debug, Display};
 use crate::model::ir::atom::Atom;
 use crate::error::Error;
 
-pub trait Sink<R> 
+pub trait Sink<'a, R> 
 {
 	fn initialize<C: Display + Debug>(&mut self, cfg: &C) -> Result<(), Error>;
-	fn accept(&mut self, atom: Atom)                      -> Result<(), Error>;
+	fn accept(&mut self, atom: Atom<'a>)                  -> Result<(), Error>;
 	fn finish(&mut self)                                  -> Result<R,  Error>;
 }

--- a/riv/src/component/sink/capture_sink.rs
+++ b/riv/src/component/sink/capture_sink.rs
@@ -8,34 +8,34 @@ use std::fmt::{Debug, Display};
 use tracing::{info, instrument};
 
 #[derive(Debug)]
-pub struct CaptureSink {
-	atoms: Vec<Atom>,
+pub struct CaptureSink<'a> {
+	atoms: Vec<Atom<'a>>,
 }
 
-impl CaptureSink {
+impl<'a> CaptureSink<'a> {
 	pub fn new() -> Self {
 		Self { atoms: Vec::new() }
 	}
 
-	pub fn into_atoms(self) -> Vec<Atom> {
+	pub fn into_atoms(self) -> Vec<Atom<'a>> {
 		self.atoms
 	}
 }
 
-impl Sink<Vec<Atom>> for CaptureSink {
+impl<'a> Sink<'_, Vec<Atom<'a>>> for CaptureSink<'a> {
 	#[instrument]
 	fn initialize<C: Display + Debug>(&mut self, _cfg: &C) -> Result<(), Error> {
 		self.atoms.clear();
 		Ok(())
 	}
 
-	fn accept(&mut self, atom: Atom) -> Result<(), Error> {
+	fn accept(&mut self, atom: Atom<'_>) -> Result<(), Error> {
 		self.atoms.push(atom);
 		Ok(())
 	}
 
 	#[instrument]
-	fn finish(&mut self) -> Result<Vec<Atom>, Error> {
+	fn finish(&mut self) -> Result<Vec<Atom<'a>>, Error> {
 		let rv: Vec<Atom> = self.atoms.drain(..).collect();
 		Ok(rv)
 	}

--- a/riv/src/component/sink/console_sink.rs
+++ b/riv/src/component/sink/console_sink.rs
@@ -14,7 +14,7 @@ impl ConsoleSink {
 	}
 }
 
-impl Sink<u64> for ConsoleSink
+impl<'a> Sink<'a, u64> for ConsoleSink
 {
 	#[instrument(level = "debug", skip_all)]
 	fn initialize<C: Display + Debug>(&mut self, cfg: &C) -> Result<(), Error> {

--- a/riv/src/component/source.rs
+++ b/riv/src/component/source.rs
@@ -21,7 +21,7 @@ pub enum SourceState<S> {
 }
 
 
-pub trait Source: Iterator<Item = Atom> {
+pub trait Source<'a>: Iterator<Item = Atom<'a>> {
 	/// Receive the configuration and move the source from Uninitialized
 	/// to either Ready(S) or Broken(Error) depending on the success of
 	/// initialization

--- a/riv/src/component/source/csv_adapter.rs
+++ b/riv/src/component/source/csv_adapter.rs
@@ -22,12 +22,12 @@ use std::fmt;
 // and I relented, for now.
 //
 
-pub struct CsvState {
-	pub header_atom:      Option<Atom>,
+pub struct CsvState<'a> {
+	pub header_atom:      Option<Atom<'a>>,
 	pub iterator:         csv::ByteRecordsIntoIter<File>,
 }
 
-impl CsvState {
+impl<'a> CsvState<'a> {
 	pub fn new(file_path: &String) -> Result<Self, Error> {
 		let file        = File::open(file_path).map_err(IoErrorWrapper::from)?;
 		let mut reader  = ReaderBuilder::new().delimiter(b';').from_reader(file);
@@ -40,7 +40,7 @@ impl CsvState {
 	}
 }
 
-impl Debug for CsvState {
+impl<'a> Debug for CsvState<'a> {
 	fn fmt(&self, fmt: &mut std::fmt::Formatter) -> fmt::Result {
 		fmt.debug_struct("CsvState")
 		.field("header_atom", &self.header_atom)

--- a/riv/src/component/source/vector_source.rs
+++ b/riv/src/component/source/vector_source.rs
@@ -6,23 +6,23 @@ use crate::model::ir::atom::Atom::ErrorAtom;
 use crate::component::source::{Source, SourceState};
 
 /// A `Source` that yields atoms from an in-memory Vec.
-pub struct VectorSource {
-	atoms:           Vec<Atom>,
+pub struct VectorSource<'a> {
+	atoms:           Vec<Atom<'a>>,
 	state:           SourceState<()>,
 	error_atom_sent: bool,
 }
 
-impl VectorSource {
+impl<'a> VectorSource<'a> {
 	/// Create a new VectorSource with the given atoms.
-	pub fn new(atoms: Vec<Atom>) -> Self {
+	pub fn new(atoms: Vec<Atom<'a>>) -> Self {
 		let state           = SourceState::Uninitialized;
 		let error_atom_sent = false;
 		Self {atoms, state, error_atom_sent}
 	}
 }
 
-impl Iterator for VectorSource {
-	type Item = Atom;
+impl<'a> Iterator for VectorSource<'a> {
+	type Item = Atom<'a>;
 
 	fn next(&mut self) -> Option<Self::Item> {
 		match &mut self.state {
@@ -55,7 +55,7 @@ impl Iterator for VectorSource {
 	}
 }
 
-impl Source for VectorSource {
+impl<'a> Source<'a> for VectorSource<'a> {
 	fn initialize<CFG: Display>(&mut self, cfg: &CFG) -> Result<(), Error> {
 		let msg = format!("[VectorSource]: initialized with config: {}", cfg);
 		println!("{msg}");

--- a/riv/src/model/ir/atom.rs
+++ b/riv/src/model/ir/atom.rs
@@ -5,7 +5,7 @@ use crate::model::ir::external_metadata::TaskVariant;
 
 
 #[derive(Debug)]
-pub enum Atom
+pub enum Atom<'a>
 {
 	// Control
 	StartTask(TaskVariant),
@@ -13,17 +13,17 @@ pub enum Atom
 	ErrorAtom(Error),
 	
 	// Data
-	ValueSequence(DataRecord),
+	ValueSequence(DataRecord<'a>),
 	NamedValues(u8),        // TODO: Figure out how I want to model this ...
 	
 	// Metadata
-	HeaderRow(DataRecord),
+	HeaderRow(DataRecord<'a>),
 	CommentRow(String),
 	BlankLine,
 	InternalMetadata         // TODO: Model this
 }
 
-impl Atom {
+impl<'a> Atom<'a> {
 	fn atom_type(&self) -> AtomType {
 		match self 
 		{

--- a/riv/src/model/ir/data_record.rs
+++ b/riv/src/model/ir/data_record.rs
@@ -1,3 +1,5 @@
+use std::{cmp, ops};
+use std::ops::Range;
 use csv::ByteRecord;
 use crate::component::source::csv_adapter::{extract_strings};
 
@@ -7,17 +9,16 @@ use crate::component::source::csv_adapter::{extract_strings};
 /// conversion into Rust's UTF-8 strings in the IR.
 ///
 #[derive(Debug)]
-pub struct DataRecord {
-	values:     Vec<String>, // Temporary representation to make progres
-	
-//	bytes:     &[u8],       // Convert to [u8] an array of bytes
-//	indices:   [u32],       // Convert to a fixed size array of indices
+pub struct DataRecord<'a> {
+	bytes:   &'a [u8],
+	ends:    Endpoints,
 }
 
-impl DataRecord {
+impl<'a> DataRecord<'a> {
 	pub fn new(r: &ByteRecord) -> Self {
-		let values = extract_strings(r);
-		DataRecord{values}
+		let bytes  = r.as_slice().iter().cloned().collect::<Vec<_>>();
+		let ends   = Endpoints::with_capacity(r.len());
+		DataRecord{bytes, ends}
 	}
 	
 //	pub fn new(bytes: &[u8], indices: Vec<usize>) -> Self {
@@ -26,10 +27,90 @@ impl DataRecord {
 //	}
 	
 	pub fn len(&self) -> u32 {
-		self.values.len() as u32
+		self.ends.len() as u32
 	}
 	
 	pub fn is_empty(&self) -> bool {
-		self.values.is_empty()
+		self.ends.len() == 0
+	}
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Endpoints {
+	/// The ending index of each field.
+	ends: Vec<usize>,
+	
+	/// The number of fields in this record.
+	///
+	len: usize,
+}
+
+impl Default for Endpoints {
+	#[inline]
+	fn default() -> Endpoints {
+		Endpoints::with_capacity(0)
+	}
+}
+
+impl Endpoints {
+	/// Create a new set of bounds with the given capacity for storing the
+	/// ends of fields.
+	#[inline]
+	fn with_capacity(capacity: usize) -> Endpoints {
+		Endpoints { ends: vec![0; capacity], len: 0 }
+	}
+
+	/// Returns the bounds of field `i`.
+	#[inline]
+	fn get(&self, i: usize) -> Option<Range<usize>> {
+		if i >= self.len {
+			return None;
+		}
+		let end = match self.ends.get(i) {
+			None => return None,
+			Some(&end) => end,
+		};
+		let start = match i.checked_sub(1).and_then(|i| self.ends.get(i)) {
+			None => 0,
+			Some(&start) => start,
+		};
+		Some(ops::Range { start, end })
+	}
+
+	/// Returns a slice of ending positions of all fields.
+	#[inline]
+	fn ends(&self) -> &[usize] {
+		&self.ends[..self.len]
+	}
+
+	/// Return the last position of the last field.
+	///
+	/// If there are no fields, this returns `0`.
+	#[inline]
+	fn end(&self) -> usize {
+		self.ends().last().map(|&i| i).unwrap_or(0)
+	}
+
+	/// Returns the number of fields in these bounds.
+	#[inline]
+	fn len(&self) -> usize {
+		self.len
+	}
+
+	/// Expand the capacity for storing field ending positions.
+	#[inline]
+	fn expand(&mut self) {
+		let new_len = self.ends.len().checked_mul(2).unwrap();
+		self.ends.resize(cmp::max(4, new_len), 0);
+	}
+
+	/// Add a new field with the given ending position.
+	#[inline]
+	fn add(&mut self, pos: usize) {
+		if self.len >= self.ends.len() {
+			self.expand();
+		}
+		self.ends[self.len] = pos;
+		self.len += 1;
 	}
 }


### PR DESCRIPTION
When dealing with a row of data, the simple and slow approach is to create an owned string for each value. That is how the `main` branch works now. This branch is an initial attempt to capture a byte slice from the underlying parser in the `RawValues` atom.

This brings up a bunch of memory management issues that need to be address. The changes on this branch show how much converting to references cascades through the codebase.

<For discussion purposes only>
<Not intended for merging as-is>